### PR TITLE
Added Commune model

### DIFF
--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -1,0 +1,2 @@
+class Commune < ApplicationRecord
+end

--- a/db/migrate/20220301131340_create_communes.rb
+++ b/db/migrate/20220301131340_create_communes.rb
@@ -1,0 +1,12 @@
+class CreateCommunes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :communes do |t|
+      t.string :name
+      t.integer :zipcod
+      t.integer :zipinsee
+      t.float :price
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,27 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2022_03_01_131340) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "communes", force: :cascade do |t|
+    t.string "name"
+    t.integer "zipcod"
+    t.integer "zipinsee"
+    t.float "price"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end

--- a/test/fixtures/communes.yml
+++ b/test/fixtures/communes.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  zipcod: 1
+  zipinsee: 1
+  price: 1.5
+
+two:
+  name: MyString
+  zipcod: 1
+  zipinsee: 1
+  price: 1.5

--- a/test/models/commune_test.rb
+++ b/test/models/commune_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CommuneTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
ctiveRecord::Schema.define(version: 2022_03_01_131340) do

  # These are extensions that must be enabled in order to support this database
  enable_extension "plpgsql"

  create_table "communes", force: :cascade do |t|
    t.string "name"
    t.integer "zipcod"
    t.integer "zipinsee"
    t.float "price"
    t.datetime "created_at", precision: 6, null: false
    t.datetime "updated_at", precision: 6, null: false
  end

end
